### PR TITLE
Keep up to date with how we should use ring-install.sh

### DIFF
--- a/jenkins/cinder-sofs-validate/20-install-dependencies.sh
+++ b/jenkins/cinder-sofs-validate/20-install-dependencies.sh
@@ -1,1 +1,0 @@
-#!/bin/bash -xue

--- a/jenkins/cinder-sofs-validate/30-install-ring.sh
+++ b/jenkins/cinder-sofs-validate/30-install-ring.sh
@@ -5,10 +5,11 @@ SUP_ADMIN_PASS=myPass
 INTERNAL_MGMT_LOGIN=super
 INTERNAL_MGMT_PASS=adminPass
 
-HOST_IP=$(ip addr show dev eth0 | sed -nr 's/.*inet ([0-9.]+).*/\1/p');
+HOST_IP=$(/sbin/ip addr show dev eth0 | sed -nr 's/.*inet ([0-9.]+).*/\1/p');
 
 source jenkins/ring-install.sh
 
+initialize
 add_source
 install_base_scality_node
 install_supervisor
@@ -16,4 +17,5 @@ install_ringsh
 build_ring
 show_ring_status
 install_sproxyd
+test_sproxyd
 install_sfused


### PR DESCRIPTION
It improves compatibility with non Ubuntu OS. In case we would
want to run cinder-sofs-validate job on Centos instead/in addition.

Also, remove an empty useless file.
