### PR TITLE
Chown /opt/git to jenkins user

### DIFF
--- a/jenkins/cinder-sofs-validate/50-run.sh
+++ b/jenkins/cinder-sofs-validate/50-run.sh
@@ -2,6 +2,7 @@
 
 sudo groupadd jenkins
 sudo gpasswd -a jenkins jenkins
+sudo chown -R jenkins:jenkins /opt/git/
 
 sudo useradd -m -U stack
 sudo gpasswd -a stack wheel


### PR DESCRIPTION
When the "master image" was created, the source code repos were
cloned with the "ubuntu" user. Some files have restrictive permissions
which prevent them to be read by the "jenkins" user.

This change has been tested here : https://37.187.159.67:5443/view/Cinder/job/cinder-sofs-validate/2838/console
