### PR TITLE
Do not pre-create the `stack` user

### DIFF
--- a/jenkins/cinder-sofs-validate/50-run.sh
+++ b/jenkins/cinder-sofs-validate/50-run.sh
@@ -4,8 +4,7 @@ sudo groupadd jenkins
 sudo gpasswd -a jenkins jenkins
 sudo chown -R jenkins:jenkins /opt/git/
 
-sudo useradd -m -U stack
-sudo gpasswd -a stack wheel
+echo "#includedir /etc/sudoers.d" | sudo tee -a /etc/sudoers
 
 export ZUUL_PROJECT=${GERRIT_PROJECT:-}
 export ZUUL_BRANCH=${GERRIT_BRANCH:-master}


### PR DESCRIPTION
It is already created by the 'setup_host()' function in functions.sh
of devstack-gate.

Re-add the "Includedir" line in /etc/sudoers because it is wipped by Jenkins
bootstrap script.
