### PR TITLE
Handle Apache KeepAlive directive for Sproxyd

### DIFF
--- a/jenkins/ring-install.sh
+++ b/jenkins/ring-install.sh
@@ -25,6 +25,14 @@ if [[ ! ${AllowEncodedSlashes:-} ]]; then
     echo "Using 'Off' as default value for 'AllowEncodedSlashes'"
 fi
 
+if [[ ! ${KeepAlive:-} ]]; then
+    KeepAlive="On"
+    echo "Using 'On' as default value for 'KeepAlive'"
+elif [[ $KeepAlive != 'On' &&  $KeepAlive != 'Off' ]]; then
+    echo "The only valid values for KeepAlive are 'On' and 'Off', $KeepAlive is an invalid value"
+    return 1
+fi
+
 export DEBIAN_FRONTEND="noninteractive"
 
 function source_distro_utils {
@@ -365,8 +373,13 @@ function amend_apache_conf {
         sudo sed -i "/DocumentRoot/a LimitRequestLine 32766" ${conf_file_prefix}*
         sudo sed -i "/DocumentRoot/a LimitRequestFieldSize 32766" ${conf_file_prefix}*
         sudo sed -i "/DocumentRoot/a AllowEncodedSlashes ${AllowEncodedSlashes}" ${conf_file_prefix}*
+        sudo sed -i "/DocumentRoot/a KeepAlive ${KeepAlive}" ${conf_file_prefix}*
+    else 
+        echo "Could not find any file matching this pattern : ${conf_file_prefix} , exiting."
+        return 1
     fi
 }
+
 
 function install_sfused {
     install_packages scality-sfused


### PR DESCRIPTION
Now that we might use two different httpd instances on the same server (because of https://github.com/scality/openstack-ci-scripts/pull/17), we need to handle the KeepAlive directive in this library.

Otherwise client code like this one (https://github.com/scality/ScalitySproxydSwift/blob/master/jenkins/swift-functional-tests/10-install-ring.sh#L4) will need to deal with that extra complexity. I should probably have put this keepalive thing directly in here in the first place.

Note also that in this PR the KeepAlive directive is set only in the Sproxyd virtualhost, which seems more reasonable to me, no need to go system wide.
