### PR TITLE
Use Neutron for the Cinder sofs jobs

### DIFF
--- a/jenkins/cinder-sofs-validate/50-run.sh
+++ b/jenkins/cinder-sofs-validate/50-run.sh
@@ -63,7 +63,11 @@ TEMPEST_STORAGE_PROTOCOL=scality
 
 ATTACH_ENCRYPTED_VOLUME_AVAILABLE=False
 
-disable_service $extra_disabled_services heat h-eng h-api h-api-cfn h-api-cw horizon trove tr-api tr-cond tr-tmgr sahara ceilometer-acompute ceilometer-acentral ceilometer-anotification ceilometer-collector ceilometer-alarm-evaluator ceilometer-alarm-notifier ceilometer-api
+# For some reason devstack-gate overwrite this variable
+FIXED_RANGE=10.0.0.0/24
+
+enable_service q-svc q-agt q-dhcp q-l3 q-meta
+disable_service $extra_disabled_services n-net heat h-eng h-api h-api-cfn h-api-cw horizon trove tr-api tr-cond tr-tmgr sahara ceilometer-acompute ceilometer-acentral ceilometer-anotification ceilometer-collector ceilometer-alarm-evaluator ceilometer-alarm-notifier ceilometer-api
 EOF
 
 if test -n "${JOB_CINDER_REPO:-}"; then

--- a/jenkins/cinder-sofs-validate/50-run.sh
+++ b/jenkins/cinder-sofs-validate/50-run.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=true
 
 export DEVSTACK_GATE_TIMEOUT=180
 export DEVSTACK_GATE_TEMPEST=1
+export TEMPEST_CONCURRENCY=1
 export RE_EXEC=true
 
 # The SOFS driver in Juno and Icehouse doesn't support volume backup

--- a/jenkins/cinder-sofs-validate/extras.d/60-sofs.sh
+++ b/jenkins/cinder-sofs-validate/extras.d/60-sofs.sh
@@ -5,5 +5,9 @@ if [[ "$1" == "stack" && "$2" == "post-config" ]]; then
         echo_summary "Configuring Nova for Scality SOFS"
         iniset $NOVA_CONF libvirt scality_sofs_mount_point /sofs
         iniset $NOVA_CONF libvirt scality_sofs_config /etc/sfused.conf
-    fi
+
+        install_package python-memcache
+        iniset $NOVA_CONF DEFAULT servicegroup_driver mc
+        iniset $NOVA_CONF DEFAULT memcached_servers 127.0.0.1:11211
+   fi
 fi


### PR DESCRIPTION
It's gives way less false negative results. For some reason nova-network is less reliable. This has been tested for more than 2 weeks now, using neutron works better for this cinder sofs job. 

Also, this patch makes use of the memcache driver for the nova service group feature, to put less pressure on the SQL database.
