### PR TITLE
Manila functional tests infrastructure

### DIFF
--- a/jenkins/manila-functional-tests/10-deploy-ring.sh
+++ b/jenkins/manila-functional-tests/10-deploy-ring.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xue
+
+# Set working directory to where the fabfile resides.
+SCRIPT_DIR=$(dirname ${0})
+cd ${SCRIPT_DIR}
+
+sudo apt-get update
+sudo apt-get -y install git-core python-dev python-virtualenv
+
+# Install heat in a virtualenv to not interfere with devstack dependencies
+virtualenv heat-venv
+set +u && source heat-venv/bin/activate && set -u
+pip install python-heatclient fabric
+
+ssh-keygen -t rsa -P '' -C manila-management -f ${MANAGEMENT_KEY_PATH}
+
+# Remove any deployed resources on error.
+trap "fab destroy" ERR
+
+# Connection attempts are bumped here to give sshd time to
+# start on the deployed infrastructure.
+fab deploy:"`cat ${MANAGEMENT_KEY_PATH}.pub`" --connection-attempts 10 \
+	-i ${MANAGEMENT_KEY_PATH} -u ${MANAGEMENT_USER}

--- a/jenkins/manila-functional-tests/20-install-openstack.sh
+++ b/jenkins/manila-functional-tests/20-install-openstack.sh
@@ -9,13 +9,16 @@ trap "set +u && source heat-venv/bin/activate && fab destroy" ERR
 
 source /tmp/manilaci-hosts
 git clone https://github.com/openstack-dev/devstack.git
-cp devstack/samples/local.conf devstack
 
-cat >> devstack/local.conf << EOF
-disable_service horizon n-net n-novnc cinder c-api c-sch c-vol
-enable_plugin manila https://github.com/openstack/manila.git
-enable_plugin scality-manila-devstack-plugin ${SCALITY_DEVSTACK_PLUGIN}
-SCREEN_LOGDIR="\${DEST}/logs"
+cat > devstack/local.conf <<-EOF
+	[[local|localrc]]
+	DATABASE_PASSWORD=testtest; RABBIT_PASSWORD=testtest; SERVICE_TOKEN=testtest; SERVICE_PASSWORD=testtest; ADMIN_PASSWORD=testtest;
+	disable_service n-net n-xvnc n-novnc n-obj h-eng h-api h-api-cfn h-api-cw horizon cinder c-api c-sch c-vol
+	enable_service q-svc q-agt q-dhcp q-l3 q-meta
+	enable_plugin manila https://github.com/openstack/manila.git
+	enable_plugin devstack-plugin-scality ${SCALITY_DEVSTACK_PLUGIN}
+	SCREEN_LOGDIR="\${DEST}/logs"
+	USE_SCALITY_FOR_GLANCE=False
 EOF
 
 devstack/stack.sh

--- a/jenkins/manila-functional-tests/20-install-openstack.sh
+++ b/jenkins/manila-functional-tests/20-install-openstack.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -xue
+
+# Set working directory to where the fabfile resides.
+SCRIPT_DIR=$(dirname ${0})
+cd ${SCRIPT_DIR}
+
+# Remove any deployed resources on error.
+trap "set +u && source heat-venv/bin/activate && fab destroy" ERR
+
+source /tmp/manilaci-hosts
+git clone https://github.com/openstack-dev/devstack.git
+cp devstack/samples/local.conf devstack
+
+cat >> devstack/local.conf << EOF
+disable_service horizon n-net n-novnc cinder c-api c-sch c-vol
+enable_plugin manila https://github.com/openstack/manila.git
+enable_plugin scality-manila-devstack-plugin ${SCALITY_DEVSTACK_PLUGIN}
+SCREEN_LOGDIR="\${DEST}/logs"
+EOF
+
+devstack/stack.sh

--- a/jenkins/manila-functional-tests/25-network.sh
+++ b/jenkins/manila-functional-tests/25-network.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -xue
+
+# Set working directory to where the fabfile resides.
+SCRIPT_DIR=$(dirname ${0})
+cd ${SCRIPT_DIR}
+
+set +u && source heat-venv/bin/activate && set -u
+trap "fab destroy" ERR
+
+source /opt/stack/devstack-plugin-scality/environment/netdef
+source /tmp/manilaci-hosts
+
+HOST_IP=$(/sbin/ip addr show dev eth0 | sed -nr 's/.*inet ([0-9.]+).*/\1/p')
+
+# Allow fab tasks to execute locally.
+cat ${MANAGEMENT_KEY_PATH}.pub >> ~/.ssh/authorized_keys
+
+fab configure_network_path:local_ip=${HOST_IP},nfs_ip=${NFS_CONNECTOR_HOST},cifs_ip=${CIFS_CONNECTOR_HOST} \
+	-i ${MANAGEMENT_KEY_PATH} -u ${MANAGEMENT_USER}

--- a/jenkins/manila-functional-tests/30-run-tempest.sh
+++ b/jenkins/manila-functional-tests/30-run-tempest.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -xue
+
+SCRIPT_DIR=$(cd $(dirname ${0}) && pwd)
+
+# Manila tempest tests are compatible with a specific version of tempest,
+# which is defined in common.sh. This basically defines a few bash functions in
+# addition to MANILA_TEMPEST_COMMIT.
+set +eu
+source /opt/stack/manila/contrib/ci/common.sh
+set -eu
+
+# Remove any deployed resources on error.
+trap "cd ${SCRIPT_DIR} && set +u && source heat-venv/bin/activate && fab destroy" ERR
+
+cd /opt/stack/tempest
+git reset --hard ${MANILA_TEMPEST_COMMIT}  # Commit used in manila gate jobs
+tox -e all-plugin manila_tempest_tests.tests.api
+
+# Create a test result report
+set +e
+sudo pip install python-subunit junitxml
+if [ $? -eq 0 ]; then
+	testr last --subunit | subunit2junitxml -o ${WORKSPACE}/manila-functional-tests.xml
+fi
+set -e

--- a/jenkins/manila-functional-tests/40-collect-artifacts.sh
+++ b/jenkins/manila-functional-tests/40-collect-artifacts.sh
@@ -10,7 +10,9 @@ mkdir -p ${ARTIFACT_DIR}
 
 # Grab logs from jenkins host
 mkdir ${JENKINS_ARTIFACT_DIR}
-cp -rL /opt/stack/logs/* ${JENKINS_ARTIFACT_DIR}
+# || true has been added to workaround this failure:
+# "cp: cannot stat ‘xxx’: No such file or directory"
+cp -rL /opt/stack/logs/* ${JENKINS_ARTIFACT_DIR} || true
 
 if [[ -f "/var/log/messages" ]]; then
     sudo cp /var/log/messages ${JENKINS_ARTIFACT_DIR}
@@ -25,4 +27,7 @@ fi
 #NFS_ARTIFACT_DIR=
 #CIFS_ARTIFACT_DIR=
 
-sudo chown -R jenkins: ${ARTIFACT_DIR}
+# || true has been added to workaround this failure:
+# "chown fails with chown: cannot dereference ‘jenkins-logs/xx’:
+# No such file or directory"
+sudo chown -R jenkins: ${ARTIFACT_DIR} || true

--- a/jenkins/manila-functional-tests/40-collect-artifacts.sh
+++ b/jenkins/manila-functional-tests/40-collect-artifacts.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -xue
+
+SCRIPT_DIR=$(cd $(dirname ${0}) && pwd)
+trap "cd ${SCRIPT_DIR} && set +u && source heat-venv/bin/activate && fab destroy" ERR
+
+ARTIFACT_DIR=${WORKSPACE}/artifacts
+JENKINS_ARTIFACT_DIR=${ARTIFACT_DIR}/jenkins
+
+mkdir -p ${ARTIFACT_DIR}
+
+# Grab logs from jenkins host
+mkdir ${JENKINS_ARTIFACT_DIR}
+cp -rL /opt/stack/logs/* ${JENKINS_ARTIFACT_DIR}
+
+if [[ -f "/var/log/messages" ]]; then
+    sudo cp /var/log/messages ${JENKINS_ARTIFACT_DIR}
+fi
+
+if [[ -f "/var/log/syslog" ]]; then
+    sudo cp /var/log/syslog ${JENKINS_ARTIFACT_DIR}
+fi
+
+# TODO Grab logs from ring and connector nodes.
+#RING_ARTIFACT_DIR=
+#NFS_ARTIFACT_DIR=
+#CIFS_ARTIFACT_DIR=
+
+sudo chown -R jenkins: ${ARTIFACT_DIR}

--- a/jenkins/manila-functional-tests/50-teardown.sh
+++ b/jenkins/manila-functional-tests/50-teardown.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xue
+
+# Set working directory to where the fabfile resides.
+SCRIPT_DIR=$(dirname ${0})
+cd ${SCRIPT_DIR}
+
+set +u && source heat-venv/bin/activate && set -u
+fab destroy

--- a/jenkins/manila-functional-tests/assets/connector/etc/exports.conf
+++ b/jenkins/manila-functional-tests/assets/connector/etc/exports.conf
@@ -1,0 +1,1 @@
+/ 127.0.0.1(rw,no_root_squash)

--- a/jenkins/manila-functional-tests/assets/connector/etc/sagentd.yaml
+++ b/jenkins/manila-functional-tests/assets/connector/etc/sagentd.yaml
@@ -1,0 +1,8 @@
+daemon_poll_period: 5
+daemons: {}
+ip_whitelist:
+- %(supervisor_host)s
+- localhost
+port: 7084
+snmp_file: /var/lib/scality-sagentd/oidlist.txt
+snmp_update_period: 5

--- a/jenkins/manila-functional-tests/assets/connector/etc/samba/smb.conf
+++ b/jenkins/manila-functional-tests/assets/connector/etc/samba/smb.conf
@@ -1,0 +1,5 @@
+[global]
+workgroup = MANILASOFS
+security = USER
+max protocol = SMB3
+registry shares = yes

--- a/jenkins/manila-functional-tests/fabfile.py
+++ b/jenkins/manila-functional-tests/fabfile.py
@@ -34,8 +34,8 @@ def add_apt_repositories(credentials):
     )
 
     # Add GPG key.
-    sudo('gpg --keyserver pool.sks-keyservers.net --recv-keys %s' % gpg_key)
-    sudo('gpg -a --export 4A23AD0E | apt-key add -')
+    put('../scality5.gpg', '/tmp')
+    sudo('apt-key add /tmp/scality5.gpg')
 
     # Hide command execution, as well as any errors to not leak credentials
     with settings(hide('running', 'aborts', 'warnings')):

--- a/jenkins/manila-functional-tests/fabfile.py
+++ b/jenkins/manila-functional-tests/fabfile.py
@@ -1,0 +1,432 @@
+import datetime
+import fabric
+import io
+import json
+import os
+import time
+
+import heatclient.client
+import keystoneclient.auth.identity.v2
+import keystoneclient.session
+
+from fabric.api import env, execute, task, put, roles, run, parallel, sudo
+from fabric.context_managers import cd, hide, prefix, settings, shell_env
+from fabric.contrib.files import append, contains, sed, upload_template
+from heatclient.common import template_utils
+
+
+@roles('nfs_connector', 'cifs_connector')
+@parallel
+def add_apt_repositories(credentials):
+    """
+    Add Scality APT repositories.
+
+    :param credentials: credentials for packages.scality.com
+    :type credentials: string
+    """
+    release = 'stable_lorien'
+    gpg_key = '4A23AD0E'
+    repository = (
+        'http://{auth:s}@packages.scality.com/{release:s}/ubuntu'.format(
+            auth=credentials,
+            release=release,
+        )
+    )
+
+    # Add GPG key.
+    sudo('gpg --keyserver pool.sks-keyservers.net --recv-keys %s' % gpg_key)
+    sudo('gpg -a --export 4A23AD0E | apt-key add -')
+
+    # Hide command execution, as well as any errors to not leak credentials
+    with settings(hide('running', 'aborts', 'warnings')):
+        repo_cmd = sudo('apt-add-repository {0:s}'.format(repository),
+                        warn_only=True)
+        if repo_cmd.failed:
+            raise Exception("Unable to add Scality repository")
+
+    # Sagentd depends on snmp-mibs-downloader, which is in multiverse.
+    sudo('apt-add-repository --enable-source multiverse')
+    sudo('apt-get -q update')
+
+
+def register_sagentd(instance_name, ip, port=7084):
+    """
+    Register an sagentd instance at the supervisor.
+
+    :param instance_name: descriptive name of the sagentd node
+    :type instance_name: string
+    :param ip: ip of the sagent node for registration
+    :type ip: string
+    :param port: port of the sagent node for registration
+    :type port: int
+    """
+    run('ringsh supervisor serverAdd {name:s}-sa '
+        '{ip:s} {port:d}'.format(name=instance_name, ip=ip, port=port))
+
+
+def create_volume(name, role, devid, connector_ip, connector_port=7002,
+                  ring="MyRing"):
+    """
+    Create a volume and associate a connector.
+
+    :param name: volume name
+    :type name: string
+    :param role: the role to associate with the connector exposing the volume
+        (nfs or cifs)
+    :type role: string
+    :param devid: device id for the volume
+    :type devid: int
+    :param connector_ip: ip of the connector exposing the volume
+    :type connector_ip: string
+    :param connector_port: port of the connector exposing the volume
+    :type connector_port: int
+    :param ring: name of the ring backing the volume (data and metadata)
+    :type ring: string
+    """
+    run('ringsh supervisor addVolume {name:s} sofs {devid:d} '
+        '{ring:s} 1 {ring:s} 1'.format(
+            name=name,
+            devid=devid,
+            ring=ring,
+        )
+    )
+
+    retries = 10
+    for retry in range(retries):
+        time.sleep(5)
+        cmd = run('ringsh supv2 addVolumeConnector {name:s} {ip:s}:{port:d} '
+            '{role:s}'.format(
+            name=name,
+            ip=connector_ip,
+            port=connector_port,
+            role=role,
+            ),
+            warn_only=True,
+        )
+        if cmd.succeeded:
+            break
+    else:
+        raise Exception("Unable to add connector to volume '%s'".format(name))
+
+
+def setup_sfused(name, supervisor_host):
+    """
+    Install sfused and register it through sagentd to the supervisor.
+
+    :param name: descriptive name of sfused role
+    :type name: string
+    :param supervisor_host: supervisor host for sagentd registration
+    :type supervisor_host: string
+    """
+    sudo('apt-get -q -y install scality-sfused')
+
+    upload_template(
+        filename='assets/connector/etc/sagentd.yaml',
+        destination='/etc',
+        context={'supervisor_host': supervisor_host},
+        use_sudo=True,
+    )
+
+    sudo('sagentd-manageconf -c /etc/sagentd.yaml add sfused-{role:s} '
+        'type=sfused port=7002 address={host:s} '
+        'path=/run/scality/connectors/sfused'.format(
+            role=name,
+            host=env.host,
+        )
+    )
+    sudo('/etc/init.d/scality-sagentd restart')
+
+    execute(register_sagentd, name, env.host, host=supervisor_host)
+
+
+def setup_connector(role, volume_name, devid, supervisor_host):
+    """
+    Deploy an sfused connector, and an associated volume.
+
+    :param role: connector role (nfs or cifs)
+    :type role: string
+    :param volume_name: the name of the SOFS volume to create and expose
+    :type volume_name: string
+    :param devid: device id to associate with the volume
+    :type devid: int
+    :param supervisor_host: hostname or ip of the supervisor for registration
+        of connector and volume
+    :type supervisor_host: string
+    """
+    setup_sfused(role, supervisor_host)
+
+    execute(create_volume, volume_name, role, devid, env.host,
+            host=supervisor_host)
+
+    # There is a delay until the sfused config is pushed after volume creation.
+    retries = 10
+    for retry in range(retries):
+        time.sleep(5)
+        cmd = sudo('sfused -X -c /etc/sfused.conf', warn_only=True)
+        if cmd.succeeded:
+            break
+    else:
+        raise Exception("Catalog init failed for '{0:s}'".format(volume_name))
+    sudo('/etc/init.d/scality-sfused restart')
+
+
+@roles('nfs_connector')
+def setup_nfs_connector(volume_name, devid, supervisor_host):
+    """
+    Deploy an sfused nfs connector and SOFS accompanying volume.
+
+    :param volume_name: the name of the SOFS volume to create and
+        expose over nfs
+    :type volume_name: string
+    :param devid: device id to associate with the volume
+    :type devid: int
+    :param supervisor_host: hostname or ip of the supervisor for registration
+        of connector and volume
+    :type supervisor_host: string
+    """
+    sudo('apt-get -q -y install nfs-common')
+    setup_connector('nfs', volume_name, devid, supervisor_host)
+    put('assets/connector/etc/exports.conf', '/etc/', use_sudo=True)
+    sudo('/etc/init.d/scality-sfused restart')
+
+
+@roles('cifs_connector')
+def setup_cifs_connector(volume_name, devid, supervisor_host):
+    """
+    Deploy an sfused cifs connector and SOFS accompanying volume.
+
+    :param volume_name: the name of the SOFS volume to create and
+        expose over cifs
+    :type volume_name: string
+    :param devid: device id to associate with the volume
+    :type devid: int
+    :param supervisor_host: hostname or ip of the supervisor for registration
+        of connector and volume
+    :type supervisor_host: string
+    """
+    setup_connector('cifs', volume_name, devid, supervisor_host)
+
+    sudo('apt-get -q -y install scality-cifs')
+    put('assets/connector/etc/samba/smb.conf', '/etc/samba', use_sudo=True)
+    sed(
+        filename='/etc/default/sernet-samba',
+        before='SAMBA_START_MODE="none"',
+        after='SAMBA_START_MODE="classic"',
+        use_sudo=True,
+    )
+
+    sudo('mkdir -p /var/run/samba')
+    sudo('testparm -s')
+
+    # The sernet-samba-smbd init script is flaky: if the parent exits
+    # to quickly, the smbd process does not have time to daemonize.
+    sudo('/etc/init.d/sernet-samba-smbd start && sleep 5')
+
+
+@roles('nfs_connector', 'cifs_connector')
+@parallel
+def install_scality_manila_utils():
+    """
+    Install the scality-manila-utils python package.
+    """
+    sudo('apt-get -q -y install git-core python-pip')
+    sudo('pip install git+https://github.com/scality/scality-manila-utils.git')
+
+
+@roles('ring')
+def setup_ring():
+    """
+    Bootstrap Scality RING (environment variable `SCAL_PASS` must be exported).
+
+    The environment variable `SCAL_PASS` is expected to hold username:password
+    for fetching scality packages.
+    """
+    install_env = {
+        'SUP_ADMIN_LOGIN': 'supadmin',
+        'SUP_ADMIN_PASS': 'supadmin',
+        'INTERNAL_MGMT_LOGIN': 'admin',
+        'INTERNAL_MGMT_PASS': 'admin',
+        'HOST_IP': env.host,
+        'SCAL_PASS': os.environ['SCAL_PASS'],
+        'AllowEncodedSlashes': 'NoDecode',
+    }
+    export_vars = ('{0:s}={1:s}'.format(k, v) for k, v in install_env.items())
+    export_cmd = 'export {0:s}'.format(' '.join(export_vars))
+
+    sudo('apt-get -q update')
+    sudo('apt-get -q -y install git-core')
+    run('git clone https://github.com/scality/openstack-ci-scripts.git')
+
+    # Hide aborts to not leak any repository passwords to console on failure.
+    with cd('openstack-ci-scripts/jenkins'), prefix(export_cmd):
+        with prefix('source ring-install.sh'), settings(hide('aborts')):
+            run('add_source')
+            run('install_base_scality_node', pty=False)  # avoid setup screen
+            run('install_supervisor')
+            run('install_ringsh')
+            run('build_ring')
+
+
+def heat_client_session():
+    """
+    Setup a keystone authenticated heat client session.
+
+    The following environment variables must be set:
+     - OS_AUTH_URL
+     - OS_TENANT_NAME
+     - OS_USERNAME
+     - OS_PASSWORD
+
+    :return: :py:class:`heatclient.client.Client`
+    """
+    auth = keystoneclient.auth.identity.v2.Password(
+        auth_url=os.environ['OS_AUTH_URL'],
+        tenant_name=os.environ['OS_TENANT_NAME'],
+        username=os.environ['OS_USERNAME'],
+        password=os.environ['OS_PASSWORD'],
+    )
+
+    keystone_session = keystoneclient.session.Session(auth=auth)
+    heat_endpoint = keystone_session.get_endpoint(
+        service_type='orchestration',
+        interface='publicURL',
+    )
+
+    return heatclient.client.Client(
+        version=1,
+        endpoint=heat_endpoint,
+        session=keystone_session,
+    )
+
+
+def deploy_infrastructure(public_key):
+    """
+    Deploy infrastructure backing ring and connectors.
+
+    Three hosts will be deployed:
+     - ring: for the purpose of hosting a single node ring and supervisor
+     - nfs_connector: for the purpose of running sfused + nfs
+     - cifs_connector: for the purpose of running sfused + samba
+
+    :param public_key: public key for infrastructure authentication
+    :type public_key: string
+    """
+    heat_client = heat_client_session()
+    template_file = 'manila-ci.yaml'
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H%M%S')
+    deployment_name='ManilaCI_{0:s}'.format(timestamp)
+    tpl_files, template = template_utils.get_template_contents(template_file)
+    api_response = heat_client.stacks.create(
+        stack_name=deployment_name,
+        template=template,
+        files=tpl_files,
+        parameters={
+            'public_key': public_key,
+            'deployment_name': deployment_name,
+        },
+    )
+
+    # Record deployment stack id.
+    stack_id = api_response['stack']['id']
+    print('Initiated Manila CI deployment: {0:s}'.format(stack_id))
+    with io.open('/tmp/manilaci-deployment', 'wb') as f:
+        json.dump({'stack_id': stack_id}, f, indent=2)
+
+
+    # Wait for deployment to complete.
+    retries = 60
+    for retry in range(retries):
+        time.sleep(5)
+        stack = heat_client.stacks.get(stack_id)
+        if stack.status == 'COMPLETE':
+            break
+    else:
+        raise Exception(
+            "Deployment of infrastructure failed. "
+            "Stack id: '{0:s}' / {1:s}".format(stack_id, stack.status)
+        )
+
+    hosts = {}
+    for out in stack.outputs:
+        hosts[out['output_key']] = out['output_value']
+
+    for host in ('ring_ip', 'nfs_ip', 'cifs_ip'):
+        if host not in hosts:
+            raise Exception("Expected '{0:s}' in deployment".format(host))
+
+    return hosts
+
+
+@task
+def deploy(public_key):
+    """
+    Deploy a single node ring with nfs and cifs connector.
+
+    Setup the infrastructure and configure required packages for integration
+    with the Scality Manila Driver.
+
+    The following environment variables must be set:
+     - OS_AUTH_URL
+     - OS_TENANT_NAME
+     - OS_USERNAME
+     - OS_PASSWORD
+
+    :param public_key: public key for infrastructure authentication
+    :type public_key: string
+    """
+    hosts = deploy_infrastructure(public_key)
+    env.roledefs = {
+        'ring': [hosts['ring_ip']],
+        'nfs_connector': [hosts['nfs_ip']],
+        'cifs_connector': [hosts['cifs_ip']],
+    }
+
+    # Write instance IPs to file.
+    # The scality-manila-devstack-plugin relies on this information.
+    infra_dumpfile = '/tmp/manilaci-hosts'
+    export_lines = u'''
+        export NFS_CONNECTOR_HOST={nfs_ip:s}
+        export CIFS_CONNECTOR_HOST={cifs_ip:s}
+        export RING_HOST={ring_ip:s}
+    '''.format(**hosts)
+
+    with io.open(infra_dumpfile, 'w') as f:
+        f.write(export_lines)
+
+    print('Wrote infrastructure to {filename:s}: {lines:s}'.format(
+        filename=infra_dumpfile,
+        lines=export_lines
+        )
+    )
+
+    execute(add_apt_repositories, os.environ['SCAL_PASS'])
+    execute(setup_ring)
+
+    execute(setup_nfs_connector, 'manila_nfs', 1, hosts['ring_ip'])
+    execute(setup_cifs_connector, 'manila_cifs', 2, hosts['ring_ip'])
+
+    execute(install_scality_manila_utils)
+
+
+@task
+def destroy(stack_id=None):
+    """
+    Tear down a deployment.
+
+    The following environment variables must be set:
+     - OS_AUTH_URL
+     - OS_TENANT_NAME
+     - OS_USERNAME
+     - OS_PASSWORD
+
+    :param stack_id: the stack id of the deployment to remove (optional)
+        if it is not given, it is assumed to be found under
+        /tmp/manilaci-deployment
+    :type stack_id: string
+    """
+    if stack_id is None:
+        with io.open('/tmp/manilaci-deployment', 'rb') as f:
+            deployment = json.load(f)
+            stack_id = deployment['stack_id']
+
+    heat_client_session().stacks.delete(stack_id)

--- a/jenkins/manila-functional-tests/manila-ci.yaml
+++ b/jenkins/manila-functional-tests/manila-ci.yaml
@@ -1,0 +1,56 @@
+heat_template_version: 2014-10-16
+description: Manila CI Infrastructure
+
+parameters:
+    deployment_name:
+        type: string
+        description: Name of infrastructure deployment, to explicitly name the resources part of the deployment
+
+    public_key:
+        type: string
+        description: Public SSH key for instance access
+
+resources:
+    ssh_key:
+        type: OS::Nova::KeyPair
+        properties:
+            public_key: { get_param: public_key }
+            name: { get_param: deployment_name }
+
+    ring:  # Single-node ring with supervisor
+        type: OS::Nova::Server
+        properties:
+            name: { str_replace: { template: deployment-RING, params: { deployment: { get_param: deployment_name }}}}
+            key_name: { get_resource: ssh_key }
+            image: Ubuntu 14.04 amd64
+            flavor: m1.medium
+            user_data_format: RAW
+
+    nfs-connector:
+        type: OS::Nova::Server
+        properties:
+            name: { str_replace: { template: deployment-NFS, params: { deployment: { get_param: deployment_name }}}}
+            key_name: { get_resource: ssh_key }
+            image: Ubuntu 14.04 amd64
+            flavor: m1.small
+            user_data_format: RAW
+
+    cifs-connector:
+        type: OS::Nova::Server
+        properties:
+            name: { str_replace: { template: deployment-CIFS, params: { deployment: { get_param: deployment_name }}}}
+            key_name: { get_resource: ssh_key }
+            image: Ubuntu 14.04 amd64
+            flavor: m1.small
+            user_data_format: RAW
+
+outputs:
+    ring_ip:
+        description: IP of single-node ring
+        value: { get_attr: [ring, first_address] }
+    nfs_ip:
+        description: IP of NFS connector
+        value: { get_attr: [nfs-connector, first_address] }
+    cifs_ip:
+        description: IP of CIFS connector
+        value: { get_attr: [cifs-connector, first_address] }


### PR DESCRIPTION
- This job introduces a heat stack with the purpose of running a Scality RING with two connectors.
- The RING installation on the stack is handled through fab tasks.
- Devstack with Manila is installed on the jclouds instance, and is configured to target the connectors (NFS and CIFS) on the heat stack.
- Manila is configured by leveraging the newly introduced https://github.com/scality/devstack-plugin-scality plugin.
- Tunnels are setup from the provder network to the connectors to allow tenants to mount shares. This depends on scality/devstack-plugin-scality#2.
