### PR TITLE
Use devstack-plugin-scality to configure our drivers

### DIFF
--- a/jenkins/cinder-sofs-validate/50-run.sh
+++ b/jenkins/cinder-sofs-validate/50-run.sh
@@ -68,6 +68,12 @@ FIXED_RANGE=10.0.0.0/24
 
 enable_service q-svc q-agt q-dhcp q-l3 q-meta
 disable_service $extra_disabled_services n-net heat h-eng h-api h-api-cfn h-api-cw horizon trove tr-api tr-cond tr-tmgr sahara ceilometer-acompute ceilometer-acentral ceilometer-anotification ceilometer-collector ceilometer-alarm-evaluator ceilometer-alarm-notifier ceilometer-api
+
+# 167.88.149.196 is a physical server in the Scality OpenStack Lab. It hosts a copy
+# of github.com/scality/devstack-plugin-scality to avoid Github's rate limiting.
+enable_plugin scality git://167.88.149.196/devstack-plugin-scality
+SCALITY_SPROXYD_ENDPOINTS=http://127.0.0.1:81/proxy/bpchord
+USE_SCALITY_FOR_SWIFT=False
 EOF
 
 if test -n "${JOB_CINDER_REPO:-}"; then
@@ -91,6 +97,13 @@ if test -n "${JOB_CINDER_REPO:-}" -o -n "${JOB_CINDER_BRANCH:-}"; then
 RECLONE=yes
 EOF
 fi
+
+# The following line is required otherwise devstack fails with "The /opt/stack/new/scality
+# project was not found; if this is a gate job, add the project to the $PROJECTS
+# variable in the job definition." See
+# https://github.com/openstack-dev/devstack/blob/a5ea08b7526bee0d9cab51000a477654726de8fe/functions-common#L536
+export PROJECTS="scality"
+git clone git://167.88.149.196/devstack-plugin-scality /opt/git/scality
 
 export DEVSTACK_LOCAL_CONFIG=$(cat $DEVSTACK_LOCAL_CONFIG_FILE)
 


### PR DESCRIPTION
Devstack doesn't support hooks in extras.d anymore. See
https://review.openstack.org/#/c/252944/
